### PR TITLE
edited information in the noaa data transformation notebook

### DIFF
--- a/cog_transformation/noaa-gggrn-concentrations.ipynb
+++ b/cog_transformation/noaa-gggrn-concentrations.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This script was used to transform the OCO-2 MIP Top-Down CO₂ Budgets dataset from netCDF to Cloud Optimized GeoTIFF (COG) format for display in the Greenhouse Gas (GHG) Center.\n"
+    "This script was used to transform the CO₂ and CH₄ datasets in txt format with hourly granularity to JSON in daily and monthly granularity for visualization in the Greenhouse Gas (GHG) Center.\n"
    ]
   },
   {


### PR DESCRIPTION
<!---
Thanks for making a contribution to ghgc-docs!
If you are updating an existing notebook feel free to delete the sections below
-->

## Description
This NOAA data transformation notebook shows a description that needs to be corrected. i.e from `This script was used to transform the OCO-2 MIP Top-Down CO₂ Budgets dataset from netCDF to Cloud Optimized GeoTIFF (COG) format for display in the Greenhouse Gas (GHG) Center` to `This script was used to transform the CO₂ and CH₄ datasets in txt format with hourly granularity to JSON in daily and monthly granularity for visualization in the Greenhouse Gas (GHG) Center.`

## What type of docs is this?

Data Transformation Documentation

## Checklist
_The following checklist ensures that our notebooks are internally consistent ([read more](https://nasa-impact.github.io/veda-docs/contributing/doc-and-notebooks))_

- [x ] The first cell contains the rendering information with author and data
- [ x] The notebook has an **Approach** section
- [ x] All the packages that are imported in the notebooks are used within the notebook
- [ x] Dependency installs are in a non-executable cell (Markdown with a code block) as a single-line `%pip install abc def` statement
- [ x] All imports are at the top of the notebook
- [ x] Any complex geometries are accessed from remote storage
- [ x] Each code cell comes after a markdown cell containing explantory text
- [ x] All cells in the notebook book have been run in order with a fresh kernel (cell numbers should be 1, 2, 3, 4, ...)
