### PR TITLE
Restructure the Docs Site

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -53,26 +53,29 @@ website:
         contents:
           - section: GHG Center Dataset Tutorials
             contents:
-              - user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
-              - user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb
-              - user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb
-              - user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb
-              - user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb
-              - user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb
               - user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb
-              - user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb
-              - user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb
-              - user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
-              - user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb
-              - user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb
-              - user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb
-              - user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb              
               - user_data_notebooks/noaa-insitu_User_Notebook.ipynb
-              - user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb
               - user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook.ipynb
-              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb   
+              - user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb
+              - user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb
+              - user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb
+              - user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb
+              - user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb
+              - user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb
+              - user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb
+              - section: "OCO-2 MIP Top-Down CO2 Budgets"
+                contents:
+                - text: "Introductory notebook"
+                  href: user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
+                - text: "Intermediate level notebook"
+                  href: user_data_notebooks/oco2-mip-National-co2budget.ipynb
+              - user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb
+              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb  
+              - user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb
+              - user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb
+              - user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb               
           - section: Community-Contributed Tutorials
             contents:
       - section: datatransformationcode.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -122,38 +122,26 @@ website:
       - section: workflow.qmd
         text: Data Flow Diagrams
         contents:
-          - section: Gridded Anthropogenic Greenhouse Gas Emissions
-            contents:
-              - data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd
-              - data_workflow/odiac-ffco2-monthgrid-v2023_Data_Flow.qmd
-              - data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd
-              - data_workflow/epa-ch4emission-grid-v2express_Data_Flow.qmd
-              - data_workflow/vulcan-ffco2-yeargrid-v4_Data_Flow.qmd  
-              - data_workflow/gra2pes-ghg-monthgrid-v1_Data_Flow.qmd 
-
-          - section: Natural Greenhouse Gas Sources Emissions and Sinks
-            contents:
-              - data_workflow/eccodarwin-co2flux-monthgrid-v5_Data_Flow.qmd
-              - data_workflow/micasa-carbonflux-daygrid-v1_Data_Flow.qmd
-              - data_workflow/gosat-based-ch4budget-yeargrid-v1_Data_Flow.qmd
-              - data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd
-              - data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd
-              - data_workflow/lpjeosim-wetlandch4-grid-v1_Data_Flow.qmd
-          - section: Large Emissions Events
-            contents:
-              - data_workflow/emit-ch4plume-v1_Data_Flow.qmd
-              - data_workflow/goes-ch4plume-v1_Data_Flow.qmd              
-          - section: Greenhouse Gas Concentrations
-            contents:
-              - data_workflow/noaa-gggrn-co2-concentrations_Data_Flow.qmd
-              - data_workflow/noaa-gggrn-ch4-concentrations_Data_Flow.qmd
-              - data_workflow/oco2geos-co2-daygrid-v10r_Data_Flow.qmd
-              - data_workflow/influx-testbed-ghg-concentrations_Data_Flow.qmd
-              - data_workflow/lam-testbed-ghg-concentrations_Data_Flow.qmd
-              - data_workflow/nec-testbed-ghg-concentrations_Data_Flow.qmd
-          - section: Socioeconomic
-            contents:
-              - data_workflow/sedac-popdensity-yeargrid5yr-v4.11_Data_Flow.qmd
+          - data_workflow/eccodarwin-co2flux-monthgrid-v5_Data_Flow.qmd
+          - data_workflow/noaa-gggrn-co2-concentrations_Data_Flow.qmd
+          - data_workflow/noaa-gggrn-ch4-concentrations_Data_Flow.qmd
+          - data_workflow/influx-testbed-ghg-concentrations_Data_Flow.qmd
+          - data_workflow/lam-testbed-ghg-concentrations_Data_Flow.qmd
+          - data_workflow/nec-testbed-ghg-concentrations_Data_Flow.qmd
+          - data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd
+          - data_workflow/emit-ch4plume-v1_Data_Flow.qmd
+          - data_workflow/goes-ch4plume-v1_Data_Flow.qmd 
+          - data_workflow/gosat-based-ch4budget-yeargrid-v1_Data_Flow.qmd
+          - data_workflow/gra2pes-ghg-monthgrid-v1_Data_Flow.qmd 
+          - data_workflow/micasa-carbonflux-daygrid-v1_Data_Flow.qmd
+          - data_workflow/oco2geos-co2-daygrid-v10r_Data_Flow.qmd
+          - data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd
+          - data_workflow/odiac-ffco2-monthgrid-v2023_Data_Flow.qmd
+          - data_workflow/sedac-popdensity-yeargrid5yr-v4.11_Data_Flow.qmd
+          - text: "U.S. Gridded Anthropogenic Methane Emissions Inventory"
+            href: data_workflow/epa-ch4emission-grid-v2express_Data_Flow.qmd
+          - data_workflow/vulcan-ffco2-yeargrid-v4_Data_Flow.qmd  
+          - data_workflow/lpjeosim-wetlandch4-grid-v1_Data_Flow.qmd             
   
 format:
   html:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -81,70 +81,44 @@ website:
       - section: datatransformationcode.qmd
         text: Data Transformation Notebooks
         contents:
-          - section: Gridded Anthropogenic Greenhouse Gas Emissions
-            contents:
-              - cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb
-              - cog_transformation/odiac-ffco2-monthgrid-v2023.ipynb
-              - cog_transformation/ct-ch4-monthgrid-v2023.ipynb
-              - cog_transformation/epa-ch4emission-grid-v2express.ipynb   
-              - cog_transformation/vulcan-ffco2-yeargrid-v4.ipynb
-              - cog_transformation/gra2pes-ghg-monthgrid-v1.ipynb
-          - section: Natural Greenhouse Gas Sources Emissions and Sinks
-            contents:
-              - cog_transformation/eccodarwin-co2flux-monthgrid-v5.ipynb
-              - cog_transformation/gosat-based-ch4budget-yeargrid-v1.ipynb
-              - cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb
-              - cog_transformation/ct-ch4-monthgrid-v2023.ipynb
-          - section: Large Emissions Events
-            contents:
-              - cog_transformation/emit-ch4plume-v1.ipynb
-              - cog_transformation/goes-ch4plume-v1.ipynb
-              
-          - section: Greenhouse Gas Concentrations
-            contents:
-              - cog_transformation/noaa-gggrn-concentrations.ipynb
-              - cog_transformation/oco2geos-co2-daygrid-v10r.ipynb
-              - cog_transformation/influx-testbed-ghg-concentrations.ipynb
-              - cog_transformation/lam-testbed-ghg-concentrations.ipynb
-              - cog_transformation/nec-testbed-ghg-concentrations.ipynb
-              
-          - section: Socioeconomic
-            contents:
-              - cog_transformation/sedac-popdensity-yeargrid5yr-v4.11.ipynb
+          - cog_transformation/eccodarwin-co2flux-monthgrid-v5.ipynb
+          - cog_transformation/noaa-gggrn-concentrations.ipynb
+          - cog_transformation/influx-testbed-ghg-concentrations.ipynb
+          - cog_transformation/lam-testbed-ghg-concentrations.ipynb
+          - cog_transformation/nec-testbed-ghg-concentrations.ipynb
+          - cog_transformation/ct-ch4-monthgrid-v2023.ipynb
+          - cog_transformation/emit-ch4plume-v1.ipynb
+          - cog_transformation/goes-ch4plume-v1.ipynb
+          - cog_transformation/gosat-based-ch4budget-yeargrid-v1.ipynb
+          - cog_transformation/gra2pes-ghg-monthgrid-v1.ipynb
+          - cog_transformation/oco2geos-co2-daygrid-v10r.ipynb
+          - cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb
+          - cog_transformation/odiac-ffco2-monthgrid-v2023.ipynb
+          - cog_transformation/sedac-popdensity-yeargrid5yr-v4.11.ipynb
+          - cog_transformation/epa-ch4emission-grid-v2express.ipynb   
+          - cog_transformation/vulcan-ffco2-yeargrid-v4.ipynb
       - section: processingreport.qmd
         text: Processing and Verification Reports
         contents:
-          - section: Gridded Anthropogenic Greenhouse Gas Emissions
-            contents:
-              - processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd
-              - processing_and_verification_reports/odiac-ffco2-monthgrid-v2023_Processing and Verification Report.qmd
-              - processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd
-              - processing_and_verification_reports/epa-ch4emission-grid-v2express_Processing and Verification Report.qmd 
-              - processing_and_verification_reports/vulcan-ffco2-yeargrid-v4_Processing and Verification Report.qmd  
-
-          - section: Natural Greenhouse Gas Sources Emissions and Sinks
-            contents:
-              - processing_and_verification_reports/eccodarwin-co2flux-monthgrid-v5_Processing and Verification Report.qmd
-              - processing_and_verification_reports/micasa-carbonflux-daygrid-v1_Processing and Verification Report.qmd
-              - processing_and_verification_reports/gosat-based-ch4budget-yeargrid-v1_Processing and Verification Report.qmd
-              - processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd
-              - processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd
-              - processing_and_verification_reports/lpjeosim-wetlandch4-grid-v1_Processing and Verification Report.qmd
-          - section: Large Emissions Events
-            contents:
-              - processing_and_verification_reports/emit-ch4plume-v1_Processing and Verification Report.qmd
-              - processing_and_verification_reports/goes-ch4plume-v1_Processing and Verification Report.qmd
-          - section: Greenhouse Gas Concentrations
-            contents:
-              - processing_and_verification_reports/noaa-gggrn-co2-concentrations_Processing and Verification Report.qmd
-              - processing_and_verification_reports/noaa-gggrn-ch4-concentrations_Processing and Verification Report.qmd
-              - processing_and_verification_reports/oco2geos-co2-daygrid-v10r_Processing and Verification Report.qmd
-              - processing_and_verification_reports/influx-testbed-ghg-concentrations_Processing and Verification Report.qmd
-              - processing_and_verification_reports/lam-testbed-ghg-concentrations_Processing and Verification Report.qmd
-              - processing_and_verification_reports/nec-testbed-ghg-concentrations_Processing and Verification Report.qmd           
-          - section: Socioeconomic
-            contents:
-              - processing_and_verification_reports/sedac-popdensity-yeargrid5yr-v4.11_Processing and Verification Report.qmd
+          - processing_and_verification_reports/eccodarwin-co2flux-monthgrid-v5_Processing and Verification Report.qmd
+          - processing_and_verification_reports/noaa-gggrn-co2-concentrations_Processing and Verification Report.qmd
+          - processing_and_verification_reports/noaa-gggrn-ch4-concentrations_Processing and Verification Report.qmd
+          - processing_and_verification_reports/influx-testbed-ghg-concentrations_Processing and Verification Report.qmd
+          - processing_and_verification_reports/lam-testbed-ghg-concentrations_Processing and Verification Report.qmd
+          - processing_and_verification_reports/nec-testbed-ghg-concentrations_Processing and Verification Report.qmd 
+          - processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd
+          - processing_and_verification_reports/emit-ch4plume-v1_Processing and Verification Report.qmd
+          - processing_and_verification_reports/goes-ch4plume-v1_Processing and Verification Report.qmd
+          - processing_and_verification_reports/gosat-based-ch4budget-yeargrid-v1_Processing and Verification Report.qmd
+          - processing_and_verification_reports/gra2pes-ghg-monthgrid-v1_Processing and Verification Report.qmd 
+          - processing_and_verification_reports/micasa-carbonflux-daygrid-v1_Processing and Verification Report.qmd
+          - processing_and_verification_reports/oco2geos-co2-daygrid-v10r_Processing and Verification Report.qmd  
+          - processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd
+          - processing_and_verification_reports/odiac-ffco2-monthgrid-v2023_Processing and Verification Report.qmd
+          - processing_and_verification_reports/sedac-popdensity-yeargrid5yr-v4.11_Processing and Verification Report.qmd
+          - processing_and_verification_reports/epa-ch4emission-grid-v2express_Processing and Verification Report.qmd 
+          - processing_and_verification_reports/vulcan-ffco2-yeargrid-v4_Processing and Verification Report.qmd  
+          - processing_and_verification_reports/lpjeosim-wetlandch4-grid-v1_Processing and Verification Report.qmd 
       - section: workflow.qmd
         text: Data Flow Diagrams
         contents:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -53,27 +53,30 @@ website:
         contents:
           - section: GHG Center Dataset Tutorials
             contents:
-              - user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb
+              - text: "Air-Sea CO~2~ Flux, ECCO-Darwin Model v5"
+                href: user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb
               - user_data_notebooks/noaa-insitu_User_Notebook.ipynb
               - user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb
-              - user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb
+              - text: "EMIT Methane Point Source Plume Complexes"
+                href: user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb
               - user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb
               - user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb
               - user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb
               - user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb
               - user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb
-              - section: "OCO-2 MIP Top-Down CO2 Budgets"
+              - section: "OCO-2 MIP Top-Down CO~2~ Budgets"
                 contents:
                 - text: "Introductory notebook"
                   href: user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
                 - text: "Intermediate level notebook"
                   href: user_data_notebooks/oco2-mip-National-co2budget.ipynb
               - user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb
-              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb  
-              - user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb
+              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb 
+              - text: "U.S. Gridded Anthropogenic Methane Emissions Inventory"
+                href: user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb
               - user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb
               - user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb               
           - section: Community-Contributed Tutorials

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -51,7 +51,7 @@ website:
       - section: datausage.qmd
         text: Data Usage Notebooks
         contents:
-          - section: Gridded Anthropogenic Greenhouse Gas Emissions
+          - section: GHG Center Dataset Tutorials
             contents:
               - user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
               - user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb
@@ -59,28 +59,22 @@ website:
               - user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb
               - user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb
               - user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb
-          - section: Natural Greenhouse Gas Sources Emissions and Sinks
-            contents:
               - user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb
               - user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb
               - user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb
               - user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb
               - user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb
               - user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb
-          - section: Large Emissions Events
-            contents:
               - user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb
               - user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb              
-          - section: Greenhouse Gas Concentrations
-            contents:
               - user_data_notebooks/noaa-insitu_User_Notebook.ipynb
               - user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb
               - user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook.ipynb
               - user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook.ipynb
-          - section: Socioeconomic
+              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb   
+          - section: Community-Contributed Tutorials
             contents:
-              - user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb          
       - section: datatransformationcode.qmd
         text: Data Transformation Notebooks
         contents:

--- a/datatransformationcode.qmd
+++ b/datatransformationcode.qmd
@@ -14,34 +14,22 @@ Explore, analyze, and make a difference with the US GHG Center.
 
 [View the US GHG Center Data Catalog](https://earth.gov/ghgcenter/data-catalog)
 
-## Gridded Anthropogenic Greenhouse Gas Emissions
-1. [OCO-2 MIP Top-Down CO₂ Budgets](cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb)
-2. [ODIAC Fossil Fuel CO₂ Emissions](cog_transformation/odiac-ffco2-monthgrid-v2023.ipynb)
-3. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes](cog_transformation/ct-ch4-monthgrid-v2023.ipynb)
-4. [U.S. Gridded Anthropogenic Methane Emissions Inventory](cog_transformation/epa-ch4emission-grid-v2express.ipynb)
-5. [Vulcan Fossil Fuel CO₂ Emissions](cog_transformation/vulcan-ffco2-yeargrid-v4.ipynb)
-6. [GRA²PES Greenhouse Gas and Air Quality Species](cog_transformation/gra2pes-ghg-monthgrid-v1.ipynb)
-
-## Natural Greenhouse Gas Emissions and Sinks
-1. [Air-Sea CO₂ Flux, ECCO-Darwin Model v5](cog_transformation/eccodarwin-co2flux-monthgrid-v5.ipynb)
-2. [GOSAT-based Top-down Total and Natural Methane Emissions](cog_transformation/gosat-based-ch4budget-yeargrid-v1.ipynb)
-3. [OCO-2 MIP Top-Down CO₂ Budgets](cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb)
-4. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes](cog_transformation/ct-ch4-monthgrid-v2023.ipynb)
-
-
-## Large Emissions Events
-1. [EMIT Methane Point Source Plume Complexes](cog_transformation/emit-ch4plume-v1.ipynb)
-2. [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure](cog_transformation/goes-ch4plume-v1.ipynb)
-
-## Greenhouse Gas Concentrations
-1. [Atmospheric Carbon Dioxide and Methane Concentrations from NOAA Global Monitoring Laboratory](cog_transformation/noaa-gggrn-concentrations.ipynb)
-2. [OCO-2 GEOS Column CO₂ Concentrations](cog_transformation/oco2geos-co2-daygrid-v10r.ipynb)
-3. [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)](cog_transformation/influx-testbed-ghg-concentrations.ipynb)
-4. [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project](cog_transformation/lam-testbed-ghg-concentrations.ipynb)
-5. [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed](cog_transformation/nec-testbed-ghg-concentrations.ipynb)
-
-## Socioeconomic
-1. [SEDAC Gridded World Population Density](cog_transformation/sedac-popdensity-yeargrid5yr-v4.11.ipynb)
+- [Air-Sea CO₂ Flux, ECCO-Darwin Model v5](cog_transformation/eccodarwin-co2flux-monthgrid-v5.ipynb)
+- [Atmospheric Carbon Dioxide and Methane Concentrations from NOAA Global Monitoring Laboratory](cog_transformation/noaa-gggrn-concentrations.ipynb)
+- [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)](cog_transformation/influx-testbed-ghg-concentrations.ipynb)
+- [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project](cog_transformation/lam-testbed-ghg-concentrations.ipynb)
+- [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed](cog_transformation/nec-testbed-ghg-concentrations.ipynb)
+- [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes](cog_transformation/ct-ch4-monthgrid-v2023.ipynb)
+- [EMIT Methane Point Source Plume Complexes](cog_transformation/emit-ch4plume-v1.ipynb)
+- [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure](cog_transformation/goes-ch4plume-v1.ipynb)
+- [GOSAT-based Top-down Total and Natural Methane Emissions](cog_transformation/gosat-based-ch4budget-yeargrid-v1.ipynb)
+- [GRA²PES Greenhouse Gas and Air Quality Species](cog_transformation/gra2pes-ghg-monthgrid-v1.ipynb)
+- [OCO-2 GEOS Column CO₂ Concentrations](cog_transformation/oco2geos-co2-daygrid-v10r.ipynb)
+- [OCO-2 MIP Top-Down CO₂ Budgets](cog_transformation/oco2-mip-co2budget-yeargrid-v1.ipynb)
+- [ODIAC Fossil Fuel CO₂ Emissions](cog_transformation/odiac-ffco2-monthgrid-v2023.ipynb)
+- [SEDAC Gridded World Population Density](cog_transformation/sedac-popdensity-yeargrid5yr-v4.11.ipynb)
+- [U.S. Gridded Anthropogenic Methane Emissions Inventory](cog_transformation/epa-ch4emission-grid-v2express.ipynb)
+- [Vulcan Fossil Fuel CO₂ Emissions](cog_transformation/vulcan-ffco2-yeargrid-v4.ipynb)
 
 ## Contact
 

--- a/datausage.qmd
+++ b/datausage.qmd
@@ -12,42 +12,42 @@ Explore, analyze, and make a difference with the US GHG Center.
 
 ## GHG Center Dataset Tutorials
 - Air-Sea CO₂ Flux, ECCO-Darwin Model v5 
-   - [Beginner level notebook](user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Air-Sea CO₂ Flux, ECCO-Darwin Model v5 dataset.
+   - [Introductory notebook](user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Air-Sea CO₂ Flux, ECCO-Darwin Model v5 dataset.
 - Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory
-   - [Beginner level notebook](user_data_notebooks/noaa-insitu_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory dataset.
+   - [Introductory notebook](user_data_notebooks/noaa-insitu_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory dataset.
 - Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)
-   - [Beginner level notebook](user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook)
+   - [Introductory notebook](user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook)
 - Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project
-   - [Beginner level notebook](user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook)
+   - [Introductory notebook](user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook)
 - Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed
-   - [Beginner level notebook](user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook)
+   - [Introductory notebook](user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook)
 - CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes
-   - [Beginner level notebook](user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes dataset.
+   - [Introductory notebook](user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes dataset.
 - EMIT Methane Point Source Plume Complexes
-   - [Beginner level notebook](user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
+   - [Introductory notebook](user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
 - Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure
-   - [Beginner level notebook](user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
+   - [Introductory notebook](user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
 - GOSAT-based Top-down Total and Natural Methane Emissions
-   - [Beginner level notebook](user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GOSAT-based Top-down Total and Natural Methane Emissions dataset.
+   - [Introductory notebook](user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GOSAT-based Top-down Total and Natural Methane Emissions dataset.
 - GRA²PES Greenhouse Gas and Air Quality Species
-   - [Beginner level notebook](user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GRA2PES, Version 1 dataset.
+   - [Introductory notebook](user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GRA2PES, Version 1 dataset.
 - MiCASA Land Carbon Flux
-   - [Beginner level notebook](user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the MiCASA Land Carbon Flux dataset.
+   - [Introductory notebook](user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the MiCASA Land Carbon Flux dataset.
 - OCO-2 GEOS Column CO₂ Concentrations
-   - [Beginner level notebook](user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 GEOS Column CO₂ Concentrations dataset.
+   - [Introductory notebook](user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 GEOS Column CO₂ Concentrations dataset.
 - OCO-2 MIP Top-Down CO₂ Budgets
-   - [Beginner level notebook](user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 MIP Top-Down CO₂ Budgets dataset.
+   - [Introductory notebook](user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 MIP Top-Down CO₂ Budgets dataset.
    - [Intermediate level notebook to read and visualize](user_data_notebooks/oco2-mip-National-co2budget.ipynb) National CO₂ Budgets using OCO-2 MIP Top-Down CO₂ Budget country total data. This notebook utilizes the country totals available at [https://ceos.org/gst/carbon-dioxide.html](https://ceos.org/gst/carbon-dioxide.html), which compliment the global 1° x 1° gridded CO₂ Budget data featured in the [US GHG Center](https://earth.gov/ghgcenter/data-catalog/oco2-mip-co2budget-yeargrid-v1).
 - ODIAC Fossil Fuel CO₂ Emissions
-   - [Beginner level notebook](user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the ODIAC Fossil Fuel CO₂ Emissions dataset.
+   - [Introductory notebook](user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the ODIAC Fossil Fuel CO₂ Emissions dataset.
 - SEDAC Gridded World Population Density
-   - [Beginner level notebook](user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the SEDAC Gridded World Population Density dataset.
+   - [Introductory notebook](user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the SEDAC Gridded World Population Density dataset.
 - U.S. Gridded Anthropogenic Methane Emissions Inventory
-   - [Beginner level notebook](user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the U.S. Gridded Anthropogenic Methane Emissions Inventory dataset.
+   - [Introductory notebook](user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the U.S. Gridded Anthropogenic Methane Emissions Inventory dataset.
 - Vulcan Fossil Fuel CO₂ Emissions
-   - [Beginner level notebook](user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Vulcan Fossil Fuel CO₂ Emissions, Version 4 dataset.
+   - [Introductory notebook](user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Vulcan Fossil Fuel CO₂ Emissions, Version 4 dataset.
 - Wetland Methane Emissions, LPJ-EOSIM model
-   - [Beginner level notebook](user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Wetland Methane Emissions, LPJ-EOSIM model dataset.
+   - [Introductory notebook](user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Wetland Methane Emissions, LPJ-EOSIM model dataset.
 
 ## Community-Contributed Tutorials
 

--- a/datausage.qmd
+++ b/datausage.qmd
@@ -10,63 +10,46 @@ Explore, analyze, and make a difference with the US GHG Center.
 
 [View the US GHG Center Data Catalog](https://earth.gov/ghgcenter/data-catalog)
 
-## Gridded Anthropogenic Greenhouse Gas Emissions
-1. OCO-2 MIP Top-Down CO₂ Budgets
+## GHG Center Dataset Tutorials
+- Air-Sea CO₂ Flux, ECCO-Darwin Model v5 
+   - [Beginner level notebook](user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Air-Sea CO₂ Flux, ECCO-Darwin Model v5 dataset.
+- Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory
+   - [Beginner level notebook](user_data_notebooks/noaa-insitu_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory dataset.
+- Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)
+   - [Beginner level notebook](user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook)
+- Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project
+   - [Beginner level notebook](user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook)
+- Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed
+   - [Beginner level notebook](user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook)
+- CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes
+   - [Beginner level notebook](user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes dataset.
+- EMIT Methane Point Source Plume Complexes
+   - [Beginner level notebook](user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
+- Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure
+   - [Beginner level notebook](user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
+- GOSAT-based Top-down Total and Natural Methane Emissions
+   - [Beginner level notebook](user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GOSAT-based Top-down Total and Natural Methane Emissions dataset.
+- GRA²PES Greenhouse Gas and Air Quality Species
+   - [Beginner level notebook](user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GRA2PES, Version 1 dataset.
+- MiCASA Land Carbon Flux
+   - [Beginner level notebook](user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the MiCASA Land Carbon Flux dataset.
+- OCO-2 GEOS Column CO₂ Concentrations
+   - [Beginner level notebook](user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 GEOS Column CO₂ Concentrations dataset.
+- OCO-2 MIP Top-Down CO₂ Budgets
    - [Beginner level notebook](user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 MIP Top-Down CO₂ Budgets dataset.
    - [Intermediate level notebook to read and visualize](user_data_notebooks/oco2-mip-National-co2budget.ipynb) National CO₂ Budgets using OCO-2 MIP Top-Down CO₂ Budget country total data. This notebook utilizes the country totals available at [https://ceos.org/gst/carbon-dioxide.html](https://ceos.org/gst/carbon-dioxide.html), which compliment the global 1° x 1° gridded CO₂ Budget data featured in the [US GHG Center](https://earth.gov/ghgcenter/data-catalog/oco2-mip-co2budget-yeargrid-v1).
-2. ODIAC Fossil Fuel CO₂ Emissions
+- ODIAC Fossil Fuel CO₂ Emissions
    - [Beginner level notebook](user_data_notebooks/odiac-ffco2-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the ODIAC Fossil Fuel CO₂ Emissions dataset.
-3. CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes
-   - [Beginner level notebook](user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes dataset.
-4. U.S. Gridded Anthropogenic Methane Emissions Inventory
+- SEDAC Gridded World Population Density
+   - [Beginner level notebook](user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the SEDAC Gridded World Population Density dataset.
+- U.S. Gridded Anthropogenic Methane Emissions Inventory
    - [Beginner level notebook](user_data_notebooks/epa-ch4emission-grid-v2express_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the U.S. Gridded Anthropogenic Methane Emissions Inventory dataset.
-5. Vulcan Fossil Fuel CO₂ Emissions
+- Vulcan Fossil Fuel CO₂ Emissions
    - [Beginner level notebook](user_data_notebooks/vulcan-ffco2-yeargrid-v4_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Vulcan Fossil Fuel CO₂ Emissions, Version 4 dataset.
-6. GRA²PES Greenhouse Gas and Air Quality Species
-   - [Beginner level notebook](user_data_notebooks/gra2pes-ghg-monthgrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GRA2PES, Version 1 dataset.
-
-## Natural Greenhouse Gas Emissions and Sinks
-1. Air-Sea CO₂ Flux, ECCO-Darwin Model v5 
-   - [Beginner level notebook](user_data_notebooks/eccodarwin-co2flux-monthgrid-v5_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Air-Sea CO₂ Flux, ECCO-Darwin Model v5 dataset.
-2. MiCASA Land Carbon Flux
-   - [Beginner level notebook](user_data_notebooks/micasa-carbonflux-daygrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the MiCASA Land Carbon Flux dataset.
-3. GOSAT-based Top-down Total and Natural Methane Emissions
-   - [Beginner level notebook](user_data_notebooks/gosat-based-ch4budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the GOSAT-based Top-down Total and Natural Methane Emissions dataset.
-4. OCO-2 MIP Top-Down CO₂ Budgets
-   - [Beginner level notebook](user_data_notebooks/oco2-mip-co2budget-yeargrid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 MIP Top-Down CO₂ Budgets dataset.
-   - [Intermediate level notebook to read and visualize](user_data_notebooks/oco2-mip-National-co2budget.ipynb)National CO₂ Budgets using OCO-2 MIP Top-Down CO₂ Budget country total data. This notebook utilizes the country totals available at ceos.org/gst/carbon-dioxide, which compliment the global 1° x 1° gridded CO₂ Budget data featured in the US GHG Center.
-5. CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes
-   - [Beginner level notebook](user_data_notebooks/ct-ch4-monthgrid-v2023_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes dataset.
-6. Wetland Methane Emissions, LPJ-EOSIM model
+- Wetland Methane Emissions, LPJ-EOSIM model
    - [Beginner level notebook](user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Wetland Methane Emissions, LPJ-EOSIM model dataset.
 
-## Large Emissions Events
-1. EMIT Methane Point Source Plume Complexes
-   - [Beginner level notebook](user_data_notebooks/emit-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
-2. Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure
-   - [Beginner level notebook](user_data_notebooks/goes-ch4plume-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the EMIT Methane Point Source Plume Complexes dataset.
-
-## Greenhouse Gas Concentrations
-1. Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory
-   - [Beginner level notebook](user_data_notebooks/noaa-insitu_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory dataset.
-2. OCO-2 GEOS Column CO₂ Concentrations
-   - [Beginner level notebook](user_data_notebooks/oco2geos-co2-daygrid-v10r_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the OCO-2 GEOS Column CO₂ Concentrations dataset.
-3. Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)
-   - [Beginner level notebook](user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook)
-4. Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project
-   - [Beginner level notebook](user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook)
-5. Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed
-   - [Beginner level notebook](user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook)
-3. Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX)
-   - [Beginner level notebook](user_data_notebooks/influx-testbed-ghg-concentrations_User_Notebook)
-4. Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project
-   - [Beginner level notebook](user_data_notebooks/lam-testbed-ghg-concentrations_User_Notebook)
-5. Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed
-   - [Beginner level notebook](user_data_notebooks/nec-testbed-ghg-concentrations_User_Notebook)
-
-## Socioeconomic
-1. SEDAC Gridded World Population Density
-   - [Beginner level notebook](user_data_notebooks/sedac-popdensity-yeargrid5yr-v4.11_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the SEDAC Gridded World Population Density dataset.
+## Community-Contributed Notebooks
 
 ## Contact
 

--- a/datausage.qmd
+++ b/datausage.qmd
@@ -49,7 +49,7 @@ Explore, analyze, and make a difference with the US GHG Center.
 - Wetland Methane Emissions, LPJ-EOSIM model
    - [Beginner level notebook](user_data_notebooks/lpjeosim-wetlandch4-grid-v1_User_Notebook.ipynb) to access, visualize, explore statistics, and create a time series of the Wetland Methane Emissions, LPJ-EOSIM model dataset.
 
-## Community-Contributed Notebooks
+## Community-Contributed Tutorials
 
 ## Contact
 

--- a/processingreport.qmd
+++ b/processingreport.qmd
@@ -13,41 +13,26 @@ Explore, analyze, and make a difference with the US GHG Center.
 
 [View the US GHG Center Data Catalog](https://earth.gov/ghgcenter/data-catalog)
 
-## Gridded Anthropogenic Greenhouse Gas Emissions
-1. [OCO-2 MIP Top-Down CO₂ Budgets Processing and Verification Report](processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd)
-2. [ODIAC Fossil Fuel CO₂ Emissions Processing and Verification Report](processing_and_verification_reports/odiac-ffco2-monthgrid-v2023_Processing and Verification Report.qmd)
-3. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Processing and Verification Report](processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd)
-4. [U.S. Gridded Anthropogenic Methane Emissions Inventory Processing and Verification Report](processing_and_verification_reports/epa-ch4emission-grid-v2express_Processing and Verification Report.qmd)
-5. [Vulcan Fossil Fuel CO₂ Emissions Processing and Verification Report](processing_and_verification_reports/vulcan-ffco2-yeargrid-v4_Processing and Verification Report.qmd)
-6. [GRA²PES Greenhouse Gas and Air Quality Species Processing and Verification Report](processing_and_verification_reports/gra2pes-ghg-monthgrid-v1_Processing and Verification Report.qmd)
-
-
-## Natural Greenhouse Gas Emissions and Sinks
-1. [Air-Sea CO₂ Flux, ECCO-Darwin Model v5 Processing and Verification Report](processing_and_verification_reports/eccodarwin-co2flux-monthgrid-v5_Processing and Verification Report.qmd)
-2. [MiCASA Land Carbon Flux Processing and Verification Report](processing_and_verification_reports/micasa-carbonflux-daygrid-v1_Processing and Verification Report.qmd)
-3. [GOSAT-based Top-down Total and Natural Methane Emissions Processing and Verification Report](processing_and_verification_reports/gosat-based-ch4budget-yeargrid-v1_Processing and Verification Report.qmd)
-4. [OCO-2 MIP Top-Down CO₂ Budgets Processing and Verification Report](processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd)
-5. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Processing and Verification Report](processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd)
-6. [Wetland Methane Emissions, LPJ-EOSIM model Processing and Verification Report](processing_and_verification_reports/lpjeosim-wetlandch4-grid-v1_Processing and Verification Report.qmd)
-6. [Wetland Methane Emissions, LPJ-EOSIM model Processing and Verification Report](processing_and_verification_reports/lpjeosim-wetlandch4-grid-v2_Processing and Verification Report.qmd)
-
-## Large Emissions Events
-1. [EMIT Methane Point Source Plume Complexes Processing and Verification Report](processing_and_verification_reports/emit-ch4plume-v1_Processing and Verification Report.qmd)
-2. [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure Processing and Verification Report](processing_and_verification_reports/goes-ch4plume-v1_Processing and Verification Report.qmd)
-
-## Greenhouse Gas Concentrations
-1. [Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory Processing and Verification Report](processing_and_verification_reports/noaa-gggrn-co2-concentrations_Processing and Verification Report.qmd)
-2. [Atmospheric Methane Concentrations from NOAA Global Monitoring Laboratory Processing and Verification Report](processing_and_verification_reports/noaa-gggrn-ch4-concentrations_Processing and Verification Report.qmd)
-3. [OCO-2 GEOS Column CO₂ Concentrations Processing and Verification Report](processing_and_verification_reports/oco2geos-co2-daygrid-v10r_Processing and Verification Report.qmd)
-3. [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Processing and Verification Report](processing_and_verification_reports/influx-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-4. [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Processing and Verification Report](processing_and_verification_reports/lam-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-5. [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Processing and Verification Report](processing_and_verification_reports/nec-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-3. [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Processing and Verification Report](processing_and_verification_reports/influx-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-4. [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Processing and Verification Report](processing_and_verification_reports/lam-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-5. [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Processing and Verification Report](processing_and_verification_reports/nec-testbed-ghg-concentrations_Processing and Verification Report.qmd)
-
-## Socioeconomic
-1. [SEDAC Gridded World Population Density Processing and Verification Report](processing_and_verification_reports/sedac-popdensity-yeargrid5yr-v4.11_Processing and Verification Report.qmd)
+- [Air-Sea CO₂ Flux, ECCO-Darwin Model v5 Processing and Verification Report](processing_and_verification_reports/eccodarwin-co2flux-monthgrid-v5_Processing and Verification Report.qmd)
+- [Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory Processing and Verification Report](processing_and_verification_reports/noaa-gggrn-co2-concentrations_Processing and Verification Report.qmd)
+- [Atmospheric Methane Concentrations from NOAA Global Monitoring Laboratory Processing and Verification Report](processing_and_verification_reports/noaa-gggrn-ch4-concentrations_Processing and Verification Report.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Processing and Verification Report](processing_and_verification_reports/influx-testbed-ghg-concentrations_Processing and Verification Report.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Processing and Verification Report](processing_and_verification_reports/lam-testbed-ghg-concentrations_Processing and Verification Report.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Processing and Verification Report](processing_and_verification_reports/nec-testbed-ghg-concentrations_Processing and Verification Report.qmd)
+- [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Processing and Verification Report](processing_and_verification_reports/ct-ch4-monthgrid-v2023_Processing and Verification Report.qmd)
+- [EMIT Methane Point Source Plume Complexes Processing and Verification Report](processing_and_verification_reports/emit-ch4plume-v1_Processing and Verification Report.qmd)
+- [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure Processing and Verification Report](processing_and_verification_reports/goes-ch4plume-v1_Processing and Verification Report.qmd)
+- [GOSAT-based Top-down Total and Natural Methane Emissions Processing and Verification Report](processing_and_verification_reports/gosat-based-ch4budget-yeargrid-v1_Processing and Verification Report.qmd)
+- [GRA²PES Greenhouse Gas and Air Quality Species Processing and Verification Report](processing_and_verification_reports/gra2pes-ghg-monthgrid-v1_Processing and Verification Report.qmd)
+- [MiCASA Land Carbon Flux Processing and Verification Report](processing_and_verification_reports/micasa-carbonflux-daygrid-v1_Processing and Verification Report.qmd)
+- [OCO-2 GEOS Column CO₂ Concentrations Processing and Verification Report](processing_and_verification_reports/oco2geos-co2-daygrid-v10r_Processing and Verification Report.qmd)
+- [OCO-2 MIP Top-Down CO₂ Budgets Processing and Verification Report](processing_and_verification_reports/oco2-mip-co2budget-yeargrid-v1_Processing and Verification Report.qmd)
+- [ODIAC Fossil Fuel CO₂ Emissions Processing and Verification Report](processing_and_verification_reports/odiac-ffco2-monthgrid-v2023_Processing and Verification Report.qmd)
+- [SEDAC Gridded World Population Density Processing and Verification Report](processing_and_verification_reports/sedac-popdensity-yeargrid5yr-v4.11_Processing and Verification Report.qmd)
+- [U.S. Gridded Anthropogenic Methane Emissions Inventory Processing and Verification Report](processing_and_verification_reports/epa-ch4emission-grid-v2express_Processing and Verification Report.qmd)
+- [Vulcan Fossil Fuel CO₂ Emissions Processing and Verification Report](processing_and_verification_reports/vulcan-ffco2-yeargrid-v4_Processing and Verification Report.qmd)
+- [Wetland Methane Emissions, LPJ-EOSIM model Processing and Verification Report](processing_and_verification_reports/lpjeosim-wetlandch4-grid-v1_Processing and Verification Report.qmd)
+- [Wetland Methane Emissions, LPJ-EOSIM model Processing and Verification Report](processing_and_verification_reports/lpjeosim-wetlandch4-grid-v2_Processing and Verification Report.qmd)
 
 ## Contact
 

--- a/workflow.qmd
+++ b/workflow.qmd
@@ -11,39 +11,25 @@ Explore, analyze, and make a difference with the US GHG Center.
 
 [View the US GHG Center Data Catalog](https://earth.gov/ghgcenter/data-catalog)
 
-## Gridded Anthropogenic Greenhouse Gas Emissions
-1. [OCO-2 MIP Top-Down CO₂ Budgets Data Flow Diagram](data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd)
-2. [ODIAC Fossil Fuel CO₂ Emissions Data Flow Diagram](data_workflow/odiac-ffco2-monthgrid-v2023_Data_Flow.qmd)
-3. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Data Flow Diagram](data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd)
-4. [U.S. Gridded Anthropogenic Methane Emissions Inventory Data Flow Diagram](data_workflow/epa-ch4emission-grid-v2express_Data_Flow.qmd)
-5. [Vulcan Fossil Fuel CO₂ Emissions Data Flow Diagram](data_workflow/vulcan-ffco2-yeargrid-v4_Data_Flow.qmd)
-6. [GRA²PES Greenhouse Gas and Air Quality Species Data Flow Diagram](data_workflow/gra2pes-ghg-monthgrid-v1_Data_Flow.qmd)
-
-## Natural Greenhouse Gas Sources Emissions and Sinks
-1. [Air-Sea CO₂ Flux, ECCO-Darwin Model v5 Data Flow Diagram](data_workflow/eccodarwin-co2flux-monthgrid-v5_Data_Flow.qmd)
-2. [MiCASA Land Carbon Flux Data Flow Diagram](data_workflow/micasa-carbonflux-daygrid-v1_Data_Flow.qmd)
-3. [GOSAT-based Top-down Total and Natural Methane Emissions Data Flow Diagram](data_workflow/gosat-based-ch4budget-yeargrid-v1_Data_Flow.qmd)
-4. [OCO-2 MIP Top-Down CO₂ Budgets Data Flow Diagram](data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd)
-5. [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Data Flow Diagram](data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd)
-6. [Wetland Methane Emissions, LPJ-EOSIM Model Data Flow Diagram](data_workflow/lpjeosim-wetlandch4-grid-v1_Data_Flow.qmd)
-
-## Large Emissions Events
-1. [EMIT Methane Point Source Plume Complexes Data Flow Diagram](data_workflow/emit-ch4plume-v1_Data_Flow.qmd)
-2. [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure Complexes Data Flow Diagram](data_workflow/goes-ch4plume-v1_Data_Flow.qmd)
-
-## Greenhouse Gas Concentrations
-1. [Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory Data Flow Diagram](data_workflow/noaa-gggrn-co2-concentrations_Data_Flow.qmd)
-2. [Atmospheric Methane Concentrations from NOAA Global Monitoring Laboratory Data Flow Diagram](data_workflow/noaa-gggrn-ch4-concentrations_Data_Flow.qmd)
-3. [OCO-2 GEOS Column CO₂ Concentrations Data Flow Diagram](data_workflow/oco2geos-co2-daygrid-v10r_Data_Flow.qmd)
-4. [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Data Flow Diagram](data_workflow/influx-testbed-ghg-concentrations_Data_Flow.qmd)
-5. [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Data Flow Diagram](data_workflow/lam-testbed-ghg-concentrations_Data_Flow.qmd)
-6. [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Data Flow Diagram](data_workflow/nec-testbed-ghg-concentrations_Data_Flow.qmd)
-4. [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Data Flow Diagram](data_workflow/influx-testbed-ghg-concentrations_Data_Flow.qmd)
-5. [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Data Flow Diagram](data_workflow/lam-testbed-ghg-concentrations_Data_Flow.qmd)
-6. [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Data Flow Diagram](data_workflow/nec-testbed-ghg-concentrations_Data_Flow.qmd)
-
-## Socioeconomic
-1. [SEDAC Gridded World Population Density Data Flow Diagram](data_workflow/sedac-popdensity-yeargrid5yr-v4.11_Data_Flow.qmd)
+- [Air-Sea CO₂ Flux, ECCO-Darwin Model v5 Data Flow Diagram](data_workflow/eccodarwin-co2flux-monthgrid-v5_Data_Flow.qmd)
+- [Atmospheric Carbon Dioxide Concentrations from NOAA Global Monitoring Laboratory Data Flow Diagram](data_workflow/noaa-gggrn-co2-concentrations_Data_Flow.qmd)
+- [Atmospheric Methane Concentrations from NOAA Global Monitoring Laboratory Data Flow Diagram](data_workflow/noaa-gggrn-ch4-concentrations_Data_Flow.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Indianapolis Flux Experiment (INFLUX) Data Flow Diagram](data_workflow/influx-testbed-ghg-concentrations_Data_Flow.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Los Angeles Megacity Carbon Project Data Flow Diagram](data_workflow/lam-testbed-ghg-concentrations_Data_Flow.qmd)
+- [Carbon Dioxide and Methane Concentrations from the Northeast Corridor (NEC) Urban Test Bed Data Flow Diagram](data_workflow/nec-testbed-ghg-concentrations_Data_Flow.qmd)
+- [CarbonTracker-CH₄ Isotopic Methane Inverse Fluxes Data Flow Diagram](data_workflow/ct-ch4-monthgrid-v2023_Data_Flow.qmd)
+- [EMIT Methane Point Source Plume Complexes Data Flow Diagram](data_workflow/emit-ch4plume-v1_Data_Flow.qmd)
+- [Geostationary Satellite Observations of Extreme and Transient Methane Emissions from Oil and Gas Infrastructure Complexes Data Flow Diagram](data_workflow/goes-ch4plume-v1_Data_Flow.qmd)
+- [GOSAT-based Top-down Total and Natural Methane Emissions Data Flow Diagram](data_workflow/gosat-based-ch4budget-yeargrid-v1_Data_Flow.qmd)
+- [GRA²PES Greenhouse Gas and Air Quality Species Data Flow Diagram](data_workflow/gra2pes-ghg-monthgrid-v1_Data_Flow.qmd)
+- [MiCASA Land Carbon Flux Data Flow Diagram](data_workflow/micasa-carbonflux-daygrid-v1_Data_Flow.qmd)
+- [OCO-2 GEOS Column CO₂ Concentrations Data Flow Diagram](data_workflow/oco2geos-co2-daygrid-v10r_Data_Flow.qmd)
+- [OCO-2 MIP Top-Down CO₂ Budgets Data Flow Diagram](data_workflow/oco2-mip-co2budget-yeargrid-v1_Data_Flow.qmd)
+- [ODIAC Fossil Fuel CO₂ Emissions Data Flow Diagram](data_workflow/odiac-ffco2-monthgrid-v2023_Data_Flow.qmd)
+- [SEDAC Gridded World Population Density Data Flow Diagram](data_workflow/sedac-popdensity-yeargrid5yr-v4.11_Data_Flow.qmd)
+- [U.S. Gridded Anthropogenic Methane Emissions Inventory Data Flow Diagram](data_workflow/epa-ch4emission-grid-v2express_Data_Flow.qmd)
+- [Vulcan Fossil Fuel CO₂ Emissions Data Flow Diagram](data_workflow/vulcan-ffco2-yeargrid-v4_Data_Flow.qmd)
+- [Wetland Methane Emissions, LPJ-EOSIM Model Data Flow Diagram](data_workflow/lpjeosim-wetlandch4-grid-v1_Data_Flow.qmd)
 
 ## Contact
 


### PR DESCRIPTION
Restructuring the GHG Docs site to remove organization by thematic area, and add a community-contributed section for data usage notebooks. Additionally, descriptions for each page (i.e. Data Usage Notebooks) will be updated.
